### PR TITLE
"overlay_image" entry in Moon Patrol's info.txt

### DIFF
--- a/arcade/Moon Patrol/info.txt
+++ b/arcade/Moon Patrol/info.txt
@@ -1,4 +1,5 @@
 game_name = "Moon Patrol"
 rom_config = "mpatrol.zip.cfg"
 overlay_config = "mpatrol.cfg"
+overlay_image = "mpatrol_udb-ovl.png"
 rom_clones = "mpatrolw"


### PR DESCRIPTION
I noticed the lack of the `overlay_image` entry when working on the new script.